### PR TITLE
Fix error handling in isRegistered route by using the correct error variable

### DIFF
--- a/routeHandler/adminHandler.js
+++ b/routeHandler/adminHandler.js
@@ -249,7 +249,7 @@ router.get('/isRegistered', authenticateAdmin, async (req, res) => {
     });
   }
   catch (error) {
-    next(err)
+    next(error)
   }
 });
 


### PR DESCRIPTION
This pull request includes a minor fix in the `routeHandler/adminHandler.js` file. The change corrects a variable name from `err` to `error` in the error-handling code to ensure consistency and proper functionality.