### PR TITLE
Add Stock Information link to Product Information dropdown in admin h…

### DIFF
--- a/views/partials/adminHeader.ejs
+++ b/views/partials/adminHeader.ejs
@@ -73,6 +73,11 @@
             </a>
             <ul class="dropdown-menu" aria-labelledby="productDropdown">
               <li>
+                <a class="dropdown-item" href="/product/stock">
+                  Stock Information
+                </a>
+              </li>
+              <li>
                 <a class="dropdown-item" href="/admin/productMetrics">
                   Off-Chain Product Metrics
                 </a>


### PR DESCRIPTION
This pull request adds a new navigation link to the admin header dropdown menu for accessing stock information.

* [`views/partials/adminHeader.ejs`](diffhunk://#diff-8c349248b8ccc213d82a72b91bbd86eaa8212d8f1fde7473c9f77103827e69d0R75-R79): Added a new menu item under the "Product Information" dropdown that links to `/product/stock` for viewing stock information.